### PR TITLE
#7:add: 出力エリアのベース機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@handsontable/react": "^14.5.0",
                 "handsontable": "^14.5.0",
+                "prop-types": "^15.8.1",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
                 "recoil": "^0.7.7"
@@ -3242,7 +3243,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3482,7 +3482,7 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -3544,8 +3544,7 @@
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-refresh": {
             "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "@handsontable/react": "^14.5.0",
         "handsontable": "^14.5.0",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recoil": "^0.7.7"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 // ここに feature の component をインポートしていく
 import InputArea from './feature/input/InputArea';
 import EditTableArea from './feature/edit-table/EditTableArea';
+import OutputArea from './feature/output/OutputArea';
 
 function App() {
     return (
@@ -10,8 +11,7 @@ function App() {
             <p>input-area</p>
             <InputArea />
             <EditTableArea />
-            <p>output-area</p>
-
+            <OutputArea />
             <p>footer</p>
         </>
     );

--- a/src/feature/input/logic.js
+++ b/src/feature/input/logic.js
@@ -16,11 +16,11 @@ functions
 ================================================== */
 
 /* ``````````````````````````````
-lineBreakDecision
+getLineBreak
 
 文字列を受け取って改行を判定する
 `````````````````````````````` */
-function lineBreakDecision(str) {
+function getLineBreak(str) {
     const counts = {
         '\n': (str.match(/(?<!\r)\n/g) ?? []).length,
         '\r\n': (str.match(/\r\n/g) ?? []).length,
@@ -30,11 +30,11 @@ function lineBreakDecision(str) {
 }
 
 /* ``````````````````````````````
-delimiterDecision
+getDelimiter
 
 文字列を受け取って区切り文字を判定する
 `````````````````````````````` */
-function delimiterDecision(str) {
+function getDelimiter(str) {
     const counts = [];
     delimiters.forEach(delimiter => {
         counts.push((str?.match(new RegExp(delimiter, 'g')) ?? []).length);
@@ -57,11 +57,11 @@ function parseInput(inData) {
     const data = normalizeLineBreak(inData)
 
     // 改行文字判定後、1次元配列作成 (EOFに改行があった場合は除去する)
-    const lineBreakPtn = lineBreakDecision(data) === '\n' ? '\n' : '\r\n';
+    const lineBreakPtn = getLineBreak(data);
     const rows = data.split(lineBreakPtn).filter(el => el);
 
     // 区切り文字判定後、2次元配列を作成し返却
-    const delimiter = delimiterDecision(rows[0]);
+    const delimiter = getDelimiter(rows[0]);
     const pattern = new RegExp(`${delimiter}(?=(?:[^"]*"[^"]*")*[^"]*$)`, 'g');
     return rows.map(row => row.split(pattern));
 }

--- a/src/feature/output/CheckboxInput.jsx
+++ b/src/feature/output/CheckboxInput.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+
+const CheckboxInput = ({ parentKey, childKey, handleInputChange }) => {
+    // options からチェックボックスを作る
+    const key = `${parentKey}.${childKey}`;
+    return (
+        <input
+            type="checkbox"
+            name={childKey}
+            id={childKey}
+            onChange={e => handleInputChange(key, e.target.checked)}
+        />
+    );
+};
+CheckboxInput.propTypes = {
+    parentKey: PropTypes.string.isRequired,
+    childKey: PropTypes.string.isRequired,
+    handleInputChange: PropTypes.func.isRequired,
+};
+
+export default CheckboxInput;

--- a/src/feature/output/ConfigSection.jsx
+++ b/src/feature/output/ConfigSection.jsx
@@ -1,0 +1,110 @@
+/* ==================================================
+インポート
+
+================================================== */
+// import { useState } from 'react';
+import PropTypes from 'prop-types';
+/* ``````````````````````````````
+カスタムフック
+`````````````````````````````` */
+import useModal from '@/hooks/useModal';
+/* ``````````````````````````````
+コンポーネント
+`````````````````````````````` */
+import CustomLabel from './CustomLabel';
+import TextInput from './TextInput';
+import CheckboxInput from './CheckboxInput';
+import KeyColumnModal from './KeyColumnModal';
+
+/* ==================================================
+メインコンポーネント
+
+================================================== */
+const ConfigSection = ({ sqlType, sqlSetting, handleInputChange }) => {
+    const { modals, modalStates, openModal, closeModal } = useModal({
+        useInWhere: false,
+        useInSet: false,
+    });
+
+    return (
+        <ul>
+            {/* tableName */}
+            <li>
+                <CustomLabel keyName="tableName" />
+                <TextInput
+                    keyName="tableName"
+                    value={sqlSetting.tableName}
+                    handleInputChange={handleInputChange}
+                />
+            </li>
+
+            {/* columns */}
+            {/* HACK: modal本体はループで生成するので、ゆくゆくはこっちもループ生成に揃える。 */}
+            {sqlSetting.columns && sqlType === 'update' && (
+                <>
+                    <li>
+                        <CustomLabel keyName="where" />
+                        <button onClick={() => openModal('useInWhere')}>
+                            add
+                        </button>
+                    </li>
+                    <li>
+                        <CustomLabel keyName="set" />
+                        <button onClick={() => openModal('useInSet')}>
+                            add
+                        </button>
+                    </li>
+                </>
+            )}
+
+            {/* options */}
+            {Object.entries(sqlSetting['options']).map(([childKey]) => {
+                return (
+                    <li key={childKey}>
+                        <CustomLabel keyName={childKey} />
+                        <CheckboxInput
+                            parentKey="options"
+                            childKey={childKey}
+                            handleInputChange={handleInputChange}
+                        />
+                    </li>
+                );
+            })}
+
+            {/* モーダル */}
+            {modals.map(modalRole => (
+                <KeyColumnModal
+                    key={modalRole}
+                    isOpen={modalStates[modalRole]}
+                    onClose={closeModal}
+                    handleInputChange={handleInputChange}
+                    columns={sqlSetting.columns || []}
+                    role={modalRole}
+                />
+            ))}
+        </ul>
+    );
+};
+
+ConfigSection.propTypes = {
+    sqlType: PropTypes.oneOf(['update', 'insert']).isRequired,
+    sqlSetting: PropTypes.shape({
+        tableName: PropTypes.string.isRequired,
+        options: PropTypes.shape({
+            createFlag: PropTypes.bool,
+            dropFlag: PropTypes.bool,
+            safeUpdatesFlag: PropTypes.bool,
+            transactionFlag: PropTypes.bool,
+        }).isRequired,
+        columns: PropTypes.arrayOf(
+            PropTypes.shape({
+                name: PropTypes.string,
+                useInWhere: PropTypes.bool,
+                useInSet: PropTypes.bool,
+            })
+        ),
+    }).isRequired,
+    handleInputChange: PropTypes.func.isRequired,
+};
+
+export default ConfigSection;

--- a/src/feature/output/CustomLabel.jsx
+++ b/src/feature/output/CustomLabel.jsx
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types';
+
+const CustomLabel = ({ keyName }) => (
+    <label htmlFor={keyName}>{keyName} : </label>
+);
+CustomLabel.propTypes = { keyName: PropTypes.string.isRequired };
+
+export default CustomLabel;

--- a/src/feature/output/KeyColumnModal.jsx
+++ b/src/feature/output/KeyColumnModal.jsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+/* ==================================================
+メインコンポーネント
+
+チェック状態をローカル管理する。開いている間はローカルでのみ状態管理し、閉じるときに最終的な状態を親へ同期させる。
+================================================== */
+const KeyColumnModal = ({
+    isOpen,
+    onClose,
+    handleInputChange,
+    columns,
+    role,
+}) => {
+    const [columnsState, setColumnsState] = useState([]);
+    useEffect(() => {
+        setColumnsState(structuredClone(columns));
+    }, [isOpen, columns]);
+
+    const handleModalClose = () => {
+        const [key, value] = ['columns', columnsState];
+        // モーダルを閉じるタイミングで ローカルステートと親のステートを同期させる( 親： sqlSetting.columns を変更 ）
+        if (isOpen) handleInputChange(key, value);
+        onClose(role);
+    };
+
+    const handleOnchange = (e, eventIdx) => {
+        // チェックイベントカラムを特定し、ローカルステートのチェック状態を上書きする
+        const updateColumns = columnsState.map((prevCol, idx) =>
+            eventIdx === idx
+                ? { ...prevCol, [role]: e.target.checked }
+                : prevCol
+        );
+        setColumnsState(updateColumns);
+    };
+
+    if (!isOpen) return null;
+    return (
+        <div className="modal-overlay" onClick={handleModalClose}>
+            <div className="modal-content" onClick={e => e.stopPropagation()}>
+                <div className="columns-selector">
+                    {columnsState.map((col, idx) => (
+                        <div className="checkbox-wrapper" key={idx}>
+                            <input
+                                type="checkbox"
+                                name={`col${idx + 1}`}
+                                id={`col${idx + 1}`}
+                                value={col.name}
+                                checked={col[role]}
+                                onChange={e => handleOnchange(e, idx)}
+                            />
+                            <label htmlFor={`col${idx + 1}`}>{col.name}</label>
+                        </div>
+                    ))}
+                </div>
+                <button className="modal-close" onClick={handleModalClose}>
+                    Close
+                </button>
+            </div>
+        </div>
+    );
+};
+
+KeyColumnModal.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    handleInputChange: PropTypes.func.isRequired,
+    columns: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string,
+            useInWhere: PropTypes.bool,
+            useInSet: PropTypes.bool,
+        })
+    ).isRequired,
+    role: PropTypes.oneOf(['useInWhere', 'useInSet']),
+};
+
+export default KeyColumnModal;

--- a/src/feature/output/OutputArea.jsx
+++ b/src/feature/output/OutputArea.jsx
@@ -1,0 +1,224 @@
+/* ==================================================
+インポート
+
+================================================== */
+import { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+/* ``````````````````````````````
+ストア
+`````````````````````````````` */
+import {
+    tableDataHeaderSelector,
+    tableDataBodySelector,
+} from '@/stores/table-data/table-data-atom';
+/* ``````````````````````````````
+コンポーネント
+`````````````````````````````` */
+import ConfigSection from './ConfigSection';
+import SqlModeToggleButton from './SqlModeToggleButton';
+/* ``````````````````````````````
+ロジック
+`````````````````````````````` */
+import helper from './logic';
+
+/* ==================================================
+共通変数
+
+================================================== */
+const TYPES = { insert: 'insert', update: 'update' };
+const DEFAULT_TABLE_NAME = 'tableName';
+const SAFE_UPDATES_QUERY = {
+    head: 'SET sql_safe_updates = 0;',
+    tail: 'SET sql_safe_updates = 1;',
+};
+const TRANSACTION_QUERY = {
+    head: 'BEGIN\n',
+    tail: 'ROLLBACK;\n-- COMMIT;',
+};
+
+/* ==================================================
+メインコンポーネント
+
+================================================== */
+const OutputArea = () => {
+    const header = useRecoilValue(tableDataHeaderSelector); // カラム情報を配列で保持。各sqlの生成に使う
+    const body = useRecoilValue(tableDataBodySelector);
+    const [sqlType, setSqlType] = useState(TYPES.insert); //タイプは 'insert' or 'update' の2種
+    const columns = header.map(col => ({
+        name: col,
+        useInWhere: false,
+        useInSet: false,
+    }));
+    const [sqlSetting, setSqlSetting] = useState({
+        // 設定: タイプに合った設定内容を保持
+        tableName: DEFAULT_TABLE_NAME,
+        options: {
+            createFlag: false,
+            dropFlag: false,
+        },
+    });
+    const [insertQuery, setInsertQuery] = useState('');
+    const [updateQuery, setUpdateQuery] = useState('');
+
+    /* ``````````````````````````````
+    handleSqlType
+
+    SQLタイプの変更 と タイプに対応したSQLセッティング の設定をする
+    `````````````````````````````` */
+    const handleSqlType = type => {
+        if (sqlType === type) return;
+        const setting = helper.updateSqlSetting(
+            type,
+            columns,
+            DEFAULT_TABLE_NAME
+        );
+        setSqlType(type);
+        setSqlSetting(setting);
+    };
+
+    /* ``````````````````````````````
+    handleInputChange
+
+    子要素の onChangeイベントで利用される。
+    変更内容を SQLセッティングへ 反映させる
+   `````````````````````````````` */
+    const handleInputChange = (key, value) => {
+        setSqlSetting(prev => helper.handleUpsateSqlSetting(prev, key, value));
+    };
+
+    /* ----------------------------------------
+    SQL
+
+    ---------------------------------------- */
+
+    /* ``````````````````````````````
+    -- create
+    
+    `````````````````````````````` */
+    const setCreateStatement = (currentTableName, header) => {
+        const query = helper.generateCreateQuery(currentTableName, header);
+        setOptionalQuerys(prev => ({
+            ...prev,
+            create: query.head + query.body + query.tail,
+        }));
+    };
+
+    /* ``````````````````````````````
+    -- drop
+    
+    `````````````````````````````` */
+    const setDropStatement = currentTableName => {
+        setOptionalQuerys(prev => ({
+            ...prev,
+            drop: `DROP TABLE IF EXISTS \`${currentTableName}\`;`,
+        }));
+    };
+
+    /* ``````````````````````````````
+    -- insert
+    
+    `````````````````````````````` */
+    const setInsertStatement = (currentTableName, header, body) => {
+        const query = helper.generateInsertQuery(
+            currentTableName,
+            header,
+            body
+        );
+        setInsertQuery(query.head + query.body + query.tail);
+    };
+
+    /* ``````````````````````````````
+    -- update
+    
+    `````````````````````````````` */
+    // TODO: columnsを利用してupdateクエリを作成する。
+    const setUpdateStatement = (currentTableName, columnsState, body) => {
+        const querys = helper.generateUpdateQuery(
+            currentTableName,
+            columnsState,
+            body
+        );
+        setUpdateQuery(querys);
+    };
+
+    /* ``````````````````````````````
+    -- option
+    
+    `````````````````````````````` */
+    const [optionalQuerys, setOptionalQuerys] = useState({
+        create: '',
+        drop: '',
+        safeUpdates: SAFE_UPDATES_QUERY,
+        transaction: TRANSACTION_QUERY,
+    });
+
+    const displayStyle = keyFlag => ({
+        display: keyFlag ? 'block' : 'none',
+        whiteSpace: 'pre-wrap',
+    });
+
+    /* ==================================================
+    useEffect
+
+    ================================================== */
+    useEffect(() => {
+        setCreateStatement(sqlSetting.tableName, header);
+        setDropStatement(sqlSetting.tableName);
+        if (sqlType === 'insert')
+            setInsertStatement(sqlSetting.tableName, header, body);
+        if (sqlType === 'update')
+            setUpdateStatement(sqlSetting.tableName, sqlSetting.columns, body);
+    }, [header, body, sqlSetting, sqlType]);
+
+    /* ==================================================
+    return
+
+    ================================================== */
+    return (
+        <>
+            <div>
+                <SqlModeToggleButton
+                    type={TYPES.insert}
+                    sqlType={sqlType}
+                    onClick={handleSqlType}
+                />
+                <SqlModeToggleButton
+                    type={TYPES.update}
+                    sqlType={sqlType}
+                    onClick={handleSqlType}
+                />
+
+                <h3>Setting↓↓</h3>
+                <ConfigSection
+                    sqlType={sqlType}
+                    sqlSetting={sqlSetting}
+                    handleInputChange={handleInputChange}
+                />
+            </div>
+            <h3>OutPut</h3>
+            <div style={{ height: '15rem' }}>
+                <div style={displayStyle(sqlSetting.options.dropFlag)}>
+                    {optionalQuerys.drop}
+                </div>
+                <div style={displayStyle(sqlSetting.options.createFlag)}>
+                    {optionalQuerys.create}
+                </div>
+                <div style={displayStyle(sqlSetting.options.safeUpdatesFlag)}>
+                    {optionalQuerys.safeUpdates.head}
+                </div>
+                <div style={displayStyle(sqlSetting.options.transactionFlag)}>
+                    {optionalQuerys.transaction.head}
+                    {optionalQuerys.transaction.tail}
+                </div>
+                <div style={displayStyle(sqlSetting.options.safeUpdatesFlag)}>
+                    {optionalQuerys.safeUpdates.tail}
+                </div>
+                <div style={{ whiteSpace: 'pre-wrap' }}>
+                    {sqlType === 'insert' ? insertQuery : updateQuery}
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default OutputArea;

--- a/src/feature/output/SqlModeToggleButton.jsx
+++ b/src/feature/output/SqlModeToggleButton.jsx
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+
+const SqlModeToggleButton = ({ type, sqlType, onClick }) => {
+    const getButtonText = () => {
+        switch (type) {
+            case 'update':
+                return 'UPDATE';
+            case 'insert':
+                return 'INSERT';
+            default:
+                return 'UNKNOWN';
+        }
+    };
+
+    const getButtonStyle = () => ({
+        backgroundColor: sqlType === type ? 'red' : 'transparent',
+    });
+
+    return (
+        <button onClick={() => onClick(type)} style={getButtonStyle()}>
+            {getButtonText()}
+        </button>
+    );
+};
+
+SqlModeToggleButton.propTypes = {
+    type: PropTypes.oneOf(['update', 'insert']).isRequired,
+    onClick: PropTypes.func.isRequired,
+    sqlType: PropTypes.string.isRequired,
+};
+
+export default SqlModeToggleButton;

--- a/src/feature/output/TextInput.jsx
+++ b/src/feature/output/TextInput.jsx
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types';
+
+const TextInput = ({ keyName, value, handleInputChange }) => {
+    // tableName からテキストボックスを作る
+    const key = keyName;
+    return (
+        <input
+            type="text"
+            name={keyName}
+            id={keyName}
+            value={value}
+            onChange={e => handleInputChange(key, e.target.value)}
+        />
+    );
+};
+TextInput.propTypes = {
+    keyName: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+    handleInputChange: PropTypes.func.isRequired,
+};
+
+export default TextInput;

--- a/src/feature/output/logic.js
+++ b/src/feature/output/logic.js
@@ -1,0 +1,220 @@
+/* ==================================================
+ヘルパー関数
+OutputArea.jsx
+================================================== */
+/* ``````````````````````````````
+>> handleSqlType
+
+`````````````````````````````` */
+const updateSqlSetting = (type, columns, defaultTableName) => {
+    switch (type) {
+        case 'insert': // テーブル名, テーブル作成フラグ, テーブル削除フラグ
+            return {
+                tableName: defaultTableName,
+                options: {
+                    createFlag: false,
+                    dropFlag: false,
+                },
+            };
+        case 'update': // テーブル名, セーフアップデート無効化フラグ, トランザクションフラグ
+            return {
+                tableName: defaultTableName,
+                options: {
+                    safeUpdatesFlag: false,
+                    transactionFlag: false,
+                },
+                columns: columns,
+            };
+        default:
+            console.warn(`予期しないタイプ：${type}`);
+            return { unkownType: type };
+    }
+};
+/* ``````````````````````````````
+>> handleInputChange
+
+`````````````````````````````` */
+/* +++++++++++++
+カラムの状態を比較する
+各カラム要素が保持している bool値 の変更を検知する。変更があった場合は true を返す
+
++++++++++++++ */
+const compareColumns = (prevColumns, newColumns) => {
+    const newColumnsMap = new Map(newColumns.map(col => [col.name, col]));
+
+    // 比較ロジック
+    return prevColumns.some(prevCol => {
+        const matchingNewCol = newColumnsMap.get(prevCol.name);
+        return (
+            !matchingNewCol ||
+            prevCol.useInWhere !== matchingNewCol.useInWhere ||
+            prevCol.useInSet !== matchingNewCol.useInSet
+        );
+    });
+};
+
+/* +++++++++++++
+key でオブジェクト.プロパティ名を判定し
+該当プロパティのみ更新された状態のオブジェクトを返す
+
++++++++++++++ */
+const handleUpsateSqlSetting = (prev, key, value) => {
+    const propertyName = key.split('.')[0];
+    switch (propertyName) {
+        /* options */
+        case 'options': {
+            const [parentKey, childKey] = key.split('.');
+            return {
+                ...prev,
+                [parentKey]: { ...prev[parentKey], [childKey]: value },
+            };
+        }
+        /* columns */
+        case 'columns': {
+            const hasDifference = compareColumns(prev[key], value);
+            return {
+                ...prev,
+                [key]: hasDifference ? value : prev[key],
+            };
+        }
+        /* tableName */
+        case 'tableName':
+            return {
+                ...prev,
+                [key]: value,
+            };
+        default:
+            console.warn('更新失敗。該当プロパティが存在しません。');
+            return prev;
+    }
+};
+
+/* ``````````````````````````````
+>> sql
+    -- 共通ヘルパー
+
+`````````````````````````````` */
+// NULL, TRUE, FALSE 以外の値にクォーテーションをつけて返す処理
+const formatValue = val => {
+    const regx = /^(NULL|TRUE|FALSE)$/i;
+    return regx.test(val) ? val : `'${val}'`;
+};
+
+// null か undifind の要素は空文字へ置換する
+const fillEmptyStrings = body => body.map(row => row.map(col => col ?? ''));
+
+/* ``````````````````````````````
+>> sql
+    -- create
+
+`````````````````````````````` */
+const generateCreateQuery = (currentTableName, header) => ({
+    head: `CREATE TABLE ${currentTableName} (\n`,
+    body: header.reduce(
+        (acc, cur, idx, arr) =>
+            idx === arr.length - 1
+                ? acc + `\t${cur}\tVARCHAR(512)\n`
+                : acc + `\t${cur}\tVARCHAR(512),\n`,
+        ''
+    ),
+    tail: ');',
+});
+
+/* ``````````````````````````````
+>> sql
+    -- insert
+
+`````````````````````````````` */
+const generateInsertQuery = (currentTableName, header, body) => {
+    const columns = header.reduce(
+        (acc, cur, idx, arr) =>
+            idx === arr.length - 1 ? acc + `\`${cur}\`` : acc + `\`${cur}\`, `,
+        ''
+    );
+
+    // reduce でマルチインサートの `value行` を作っていく
+    const values = fillEmptyStrings(body).reduce(
+        (acc, cur, idx, arr) =>
+            idx === arr.length - 1
+                ? acc + cur.reduce( // 最終行： 改行インデントを付加しない
+                    (acc, cur, idx, arr) =>
+                        idx === arr.length - 1
+                            ? acc + `${formatValue(cur)})`
+                            : acc + `${formatValue(cur)}, `,
+                    '('
+                )
+                : acc + cur.reduce( // 最終行でない: 改行インデントを付加する
+                    (acc, cur, idx, arr) => {
+                        return idx === arr.length - 1
+                            ? acc + `${formatValue(cur)}),\n\t`
+                            : acc + `${formatValue(cur)}, `;
+                    }, '('),
+        ''
+    );
+
+    return {
+        head: `INSERT INTO \`${currentTableName}\`\n\t(${columns})\n`,
+        body: `VALUES\n\t${values}\n`,
+        tail: ';',
+    };
+};
+
+/* ``````````````````````````````
+>> sql
+    -- update
+
+`````````````````````````````` */
+// 第2引数が`true`の要素を抽出対象とする。 `カラム名` と 対応する値の`インデックス` のセットを格納した2次元配列を返却する
+const filterColumns = (columns, property) =>
+    columns.map(((col, idx) => col[property] ? [col.name, idx] : [])).filter(el => el.length > 0);
+
+// WHERE句のカラムと値を繋ぐオペレータを判定し返却する
+const getOperator = val => {
+    const regx = /^NULL$/i;
+    return regx.test(val) ? 'IS' : '=';
+};
+
+// `対象カラム`と`対応する値`を取り出し、1行ずつクエリを作成していく
+const generateUpdateQuery = (currentTableName, columnsState, body) => {
+    const headStatement = `UPDATE \`${currentTableName}\``;
+    const tailStatement = ';'
+
+    // 対象カラムの抽出。第2引数の 
+    const setColumns = filterColumns(columnsState, 'useInSet');
+    const whereColumns = filterColumns(columnsState, 'useInWhere');
+
+    // クエリ作成部分 1行１クエリを生成し、配列へ格納する
+    const querys = fillEmptyStrings(body).map(row => {
+
+        const setStatement = setColumns.reduce((prev, cur) => {
+            const [col, val] = [`\`${cur[0]}\``, formatValue(row[cur[1]])]
+            return prev.length === 0 ? ' ' + `SET ${col} = ${val}` : prev + `, ${col} = ${val}`;
+        }, '');
+
+        const whereStatement = whereColumns.reduce((prev, cur) => {
+            const [col, val] = [`\`${cur[0]}\``, formatValue(row[cur[1]])]
+            const operator = getOperator(val);
+            return prev.length === 0 ? ' ' + `WHERE ${col} ${operator} ${val}` : prev + ` AND ${col} ${operator} ${val}`;
+        }, '');
+
+        return headStatement + setStatement + whereStatement + tailStatement;
+    });
+
+    return querys.reduce((prev, cur) => prev === '' ? prev + cur : prev + '\n' + cur, '')
+};
+
+
+/* ==================================================
+エクスポート
+
+================================================== */
+const helper = {
+    updateSqlSetting: updateSqlSetting,
+    compareColumns: compareColumns,
+    handleUpsateSqlSetting: handleUpsateSqlSetting,
+    generateCreateQuery: generateCreateQuery,
+    generateInsertQuery: generateInsertQuery,
+    generateUpdateQuery: generateUpdateQuery,
+};
+
+export default helper;

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+const useModal = (initialState = {}) => {
+    // HACK 整数のキーが存在すると並び順が担保できなくなる仕様になっている。厳密に制御が必要なら追加処置が必要。
+    const modals = Object.keys(initialState);
+
+    const [modalStates, setModalStates] = useState(initialState);
+
+    const openModal = modalRole => {
+        setModalStates(prev => ({ ...prev, [modalRole]: true }));
+    };
+
+    const closeModal = (modalRole, callback) => {
+        setModalStates(prev => {
+            if (prev[modalRole] && callback) callback();
+            return { ...prev, [modalRole]: false };
+        });
+
+    }
+
+    return { modals, modalStates, openModal, closeModal }
+};
+
+export default useModal;

--- a/src/stores/table-data/table-data-atom.js
+++ b/src/stores/table-data/table-data-atom.js
@@ -1,4 +1,4 @@
-import { atom } from "recoil"
+import { atom, selector } from "recoil"
 
 export const tableDataAtom = atom({
     key: 'tableDataAtom',
@@ -11,4 +11,18 @@ export const tableDataAtom = atom({
         ['data_1-4', 'data_2-4', 'data_3-4', 'data_4-4', 'data_5-4'],
     ]
     // default: []
-})
+});
+
+export const tableDataHeaderSelector = selector({
+    key: 'tableDataHeaderSelector',
+    get: ({ get }) => {
+        return get(tableDataAtom)[0];
+    },
+});
+
+export const tableDataBodySelector = selector({
+    key: 'tableDataBodySelector',
+    get: ({ get }) => {
+        return get(tableDataAtom).slice(1);
+    },
+});


### PR DESCRIPTION
追加機能
1. `SQLモード(INSERT/UPDATE) の選択`
2. `各SQLモードの設定`
3. `生成SQLの表示`


issueの残り
1. ` 機能要件＞ 4.クリップボード機能`
2. `補足＞共通＞ SELECT句の追加`

----
機能要件：
　~1　生成するSQLの種類を選択できる( UPDATE/ INSERT )~
　~2　生成するSQLの設定ができる~
　~3　生成結果が表示される~
　4　生成結果をクリップボードへコピーできる

補足：
　・SQL設定について
　　【共通】
　　　　-　~テーブル名~
　　　　-　SELECT句 の追加
　　【UPDATE】
　　　　-　~WHERE句 のキー選択~
　　　　-　~SET句 のキー選択~
　　　　-　~トランザクション の追加~
　　　　-　~セーフモード の無効化 有効化~
　　【INSERT】
　　　　-　~CREATE TABLE の追加~
　　　　-　~DROP TABLE の追加~